### PR TITLE
Release v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,22 @@
 # Vivid.vim
 
-**Vivid is a Vim plugin management solution; designed to work with, not against
+**Vivid is a minimal Vim plugin manager; designed to work with, not against
 Vim.**
 
 <!-- Badges made using https://shields.io/ -->
-[![Version Badge](https://img.shields.io/badge/Version-v1.0.0--rc.1-brightgreen.svg)](https://github.com/axvr/Vivid.vim/releases)
-[![Licence Badge](https://img.shields.io/badge/Licence-MIT-blue.svg)](https://github.com/axvr/Vivid.vim/blob/master/LICENCE)
+[![Version Badge](https://img.shields.io/badge/Version-v1.0.0-brightgreen.svg)](https://github.com/axvr/vivid.vim/releases)
+[![Licence Badge](https://img.shields.io/badge/Licence-MIT-blue.svg)](https://github.com/axvr/vivid.vim/blob/master/LICENCE)
 
 
 ## About Vivid
 
-**Vivid is a [Vim] plugin manager** built to be minimal, fast and efficient.
-Vivid is designed to allow Vim users to fine tune exactly when their plugins are
-loaded into Vim. The user is encouraged to use the tools provided by Vivid to
-define custom rules for managing their plugins, whilst keeping the process as
-simple as possible.
+**Vivid is a [Vim] plugin manager**, built to be minimal, fast and efficient.
+Vivid provides Vim users with simple, but powerful tools, which allow them to
+fine tune exactly when their plugins should be enabled.
 
-**Designed to be [extensible]()**, additional plugins can be added to change the
-default behaviour of Vivid, or add additional features and tools (**WIP**).
-
-**Vivid can be integrated into other plugins**, through the "[*Vivid Layer
-Framework*]()" (**WIP**). This allows the creation of more powerful and faster
-plugins, with much simpler implementation. The *VLF* essentially allows plugins
-to manage other plugins, independent of what plugin manager the user chose to
-use. This is possible with very little overhead because of its sheer speed, and
-tiny size.
-
+Vivid focuses on being as minimal as possible, while still getting the job
+done, because of this some features (e.g. parallel install/update of plugins)
+are outside the scope of the project.
 
 ---
 
@@ -37,10 +28,10 @@ tiny size.
 ## Quick Start
 
 See the [Vivid wiki] for more information, examples and the
-[FAQ](https://github.com/axvr/Vivid.vim/wiki/FAQ). For convenience the titles of
+[FAQ](https://github.com/axvr/vivid.vim/wiki/FAQ). For convenience the titles of
 each section below contain links to the relevant wiki sections.
 
-### [Dependencies](https://github.com/axvr/Vivid.vim/wiki/Installing-Vivid#required-dependencies)
+### [Dependencies](https://github.com/axvr/vivid.vim/wiki/Installing-Vivid#required-dependencies)
 
 Vivid requires that the [Git](https://git-scm.com) VCS is installed on your
 system, and [Vim] \(8.0+\) or [Neovim](https://neovim.io).
@@ -50,12 +41,12 @@ for other VCSs and archives feel free to create an extension to add these
 features to Vivid.
 
 
-### [Install Vivid](https://github.com/axvr/Vivid.vim/wiki/Installing-Vivid#how-to-install-vivid)
+### [Install Vivid](https://github.com/axvr/vivid.vim/wiki/Installing-Vivid#how-to-install-vivid)
 
 To install Vivid on Vim run this command in a terminal emulator:
 
 ```sh
-git clone https://github.com/axvr/Vivid.vim ~/.vim/pack/vivid/opt/Vivid.vim
+git clone https://github.com/axvr/vivid.vim ~/.vim/pack/vivid/opt/Vivid.vim
 ```
 
 Then to enable Vivid place `packadd Vivid.vim` in your Vim config (before any
@@ -65,7 +56,7 @@ plugin definitions). It's that easy no other boilerplate code is required.
 that Vim can find Vivid. See `:h 'packpath'`.
 
 
-### [Using Vivid]
+### [Using Vivid](https://github.com/axvr/vivid.vim/wiki/Managing-Plugins)
 
 By default Vivid will not enable any plugins, this is because of it's heavy
 focus on lazy loading. However this behaviour can be reversed by including
@@ -77,12 +68,12 @@ on any plugin that is being managed. The exception is the `packadd Vivid.vim`
 before any plugin config.
 
 
-#### [Adding Plugins](https://github.com/axvr/Vivid.vim/wiki/Managing-Plugins#adding-plugins)
+#### [Adding Plugins](https://github.com/axvr/vivid.vim/wiki/Managing-Plugins#adding-plugins)
 
 To add plugins for Vivid to manage, use the `Plugin` command (or `vivid#add`
 function). Vivid provides options which can be set when adding plugins. For info
 on how to use these options refer to the "[Plugin
-Options](https://github.com/axvr/Vivid.vim/wiki/Managing-Plugins#plugin-options)"
+Options](https://github.com/axvr/vivid.vim/wiki/Managing-Plugins#plugin-options)"
 section of the Wiki.
 
 ```vim
@@ -95,16 +86,13 @@ Plugin 'tpope/vim-fugitive', { 'enabled': 1 }   " Add and enable plugin by defau
 ```
 
 
-#### [Installing Plugins](https://github.com/axvr/Vivid.vim/wiki/Managing-Plugins#installing-plugins)
+#### [Installing Plugins](https://github.com/axvr/vivid.vim/wiki/Managing-Plugins#installing-plugins)
 
-<!-- TODO maybe mention the "Principle of least astonishment" -->
-Vivid applies a "[Do What I Mean](https://en.wikipedia.org/wiki/DWIM)" approach
-to plugin management. This means that when you enable a plugin, Vivid assumes
-that you want that plugin enabled, despite whether it has actually been
-installed. So when a plugin is enabled, Vivid will automatically install (if it
-hasn't already), then it will preceed to enable it.
+Usually you will never have to manually tell Vivid to install a plugin, because
+whenever a plugin is enabled, Vivid will automatically install it, if not
+already installed.
 
-The install of plugins can also be done manually through the use of the
+If you really want to manually make Vivid install a plugin(s) you can use the
 `PluginInstall` command (or `vivid#install` function).
 
 ```vim
@@ -116,7 +104,7 @@ The install of plugins can also be done manually through the use of the
 ```
 
 
-#### [Updating Plugins](https://github.com/axvr/Vivid.vim/wiki/Managing-Plugins#updating-plugins)
+#### [Updating Plugins](https://github.com/axvr/vivid.vim/wiki/Managing-Plugins#updating-plugins)
 
 Plugins can be updated by Vivid. This is done by using the `PluginUpdate`
 command (or the `vivid#update` function).
@@ -158,7 +146,7 @@ autocmd! BufRead,BufNewFile *.ts setlocal filetype=typescript
 ```
 
 
-#### [Check Plugin Status](https://github.com/axvr/Vivid.vim/wiki/Managing-Plugins#check-plugin-status)
+#### [Check Plugin Status](https://github.com/axvr/vivid.vim/wiki/Managing-Plugins#check-plugin-status)
 
 Sometimes it is useful to check whether a plugin has been enabled, but the
 problem is that not every plugin sets a `g:loaded_plugin_name` variable. Because
@@ -185,7 +173,7 @@ autocmd FileType diff,gitcommit call <SID>configure_committia()
 ```
 
 
-#### [Cleaning Plugins](https://github.com/axvr/Vivid.vim/wiki/Managing-Plugins#cleaning-plugins)
+#### [Cleaning Plugins](https://github.com/axvr/vivid.vim/wiki/Managing-Plugins#cleaning-plugins)
 
 By making use of the `PluginClean` command (or `vivid#clean` function), it is
 possible to remove in use plugins and remove all of the unused plugins. from the
@@ -203,6 +191,5 @@ plugin directory on yor system.
 <!-- Links -->
 
 [Vim]:https://www.vim.org
-[Vivid wiki]:https://github.com/axvr/Vivid.vim/wiki
-[Using Vivid]:https://github.com/axvr/Vivid.vim/wiki/Managing-Plugins
-[Enabling Plugins]:https://github.com/axvr/Vivid.vim/wiki/Managing-Plugins#enabling-plugins
+[Vivid wiki]:https://github.com/axvr/vivid.vim/wiki
+[Enabling Plugins]:https://github.com/axvr/vivid.vim/wiki/Managing-Plugins#enabling-plugins

--- a/autoload/vivid.vim
+++ b/autoload/vivid.vim
@@ -1,7 +1,7 @@
 " ==============================================================================
 " Name:         Vivid.vim
 " Author:       Alex Vear
-" HomePage:     https://github.com/axvr/Vivid.vim
+" HomePage:     https://github.com/axvr/vivid.vim
 " Licence:      MIT Licence
 " ==============================================================================
 

--- a/doc/vivid.txt
+++ b/doc/vivid.txt
@@ -13,21 +13,13 @@ Welcome to the Vivid user and developer manual		*vivid.vim*
 ==============================================================================
 1. What is Vivid?					*vivid-what-is*
 
-Vivid is a Vim plugin manager built to be minimal, fast and efficient. Vivid
-is designed to allow Vim users to fine tune exactly when their plugins are
-loaded into Vim. The user is encouraged to use the tools provided by Vivid to
-define custom rules for managing their plugins, whilst keeping the process as
-simple as possible.
+Vivid is a Vim plugin manager, built to be minimal, fast and efficient. Vivid
+provides Vim users with simple, but powerful tools, which allow them to fine
+tune exactly when their plugins should be enabled.
 
-Designed to be extensible, additional plugins can be added to change the
-default behaviour of Vivid, or add additional features and tools (WIP).
-
-Vivid can be integrated into other plugins, through the "Vivid Layer
-Framework" (WIP). This allows the creation of more powerful and faster
-plugins, with much simpler implementation. The VLF essentially allows plugins
-to manage other plugins, independent of what plugin manager the user chose to
-use. This is possible with very little overhead because of its sheer speed,
-and tiny size.
+Vivid focuses on being as minimal as possible, while still getting the job
+done, because of this some features (e.g. parallel install/update of plugins)
+are outside the scope of the project.
 
 ==============================================================================
 2. Requirements						*vivid-requirements*

--- a/doc/vivid.txt
+++ b/doc/vivid.txt
@@ -1,4 +1,4 @@
-*vivid.txt*	For Vim version 8.0	Last change: 2018 April 11
+*vivid.txt*	For Vim version 8.0	Last change: 2018 November 06
 
 
 		Vivid.vim Manual    by Alex Vear~
@@ -6,12 +6,18 @@
 
 Welcome to the Vivid user and developer manual		*vivid.vim*
 
-1. What is Vivid?	|vivid-what-is|
-2. Requirements		|vivid-requirements|
-3. How to use Vivid	|vivid-how-to|
+1. What is Vivid?		|vivid-what-is|
+2. Requirements			|vivid-requirements|
+3. Adding plugins		|vivid-add|
+4. Installing plugins		|vivid-install|
+5. Updating plugins		|vivid-update|
+6. Enabling plugins		|vivid-enable|
+7. Check plugin status		|vivid-status|
+8. Cleaning plugins		|vivid-clean|
+9. Messages			|vivid-messages|
 
 ==============================================================================
-1. What is Vivid?					*vivid-what-is*
+1. What is Vivid?						*vivid-what-is*
 
 Vivid is a Vim plugin manager, built to be minimal, fast and efficient. Vivid
 provides Vim users with simple, but powerful tools, which allow them to fine
@@ -29,10 +35,274 @@ are outside the scope of the project.
 * Any OS supported by Vim that can run shell commands (|sys-file-list|, |:!cmd|).
 
 ==============================================================================
-3. How to use Vivid					*vivid-how-to*
+3. Adding plugins						*vivid-add*
 
-[place-holder]
+In order for Vivid to know which plugins to manage, you will need to "add"
+them. Adding plugins is a simple process, and can be easily done through the
+`:Plugin` command or the `vivid#add()` function. Both the command and the function
+work in mostly the same way.
 
-For help with writing/editing this file see |help-writing|.
+Vivid heavily relies upon Git, this allows Vivid to fetch plugins from many
+different sources, even your own filesystem.
+
+A shorthand method of adding plugins from GitHub is built into Vivid. This
+allows the URLs of plugins to be shortened from
+https://github.com/tpope/vim-fugitive to `tpope/vim-fugitive`
+
+								*:Plugin*
+The :Plugin command~
+>
+	packadd Vivid.vim  " Required (this enables Vivid)
+
+	Plugin 'tpope/vim-fugitive'                     " Simple adding from GitHub
+	Plugin 'https://github.com/tpope/vim-fugitive'  " Using full remote address to plugin
+	Plugin 'tpope/vim-fugitive', { 'enabled': 1, }  " Enable plugin by default
+	Plugin 'tpope/vim-fugitive', {                  " Other options to provide to Vivid
+		\ 'name': 'fugitive',
+		\ 'enabled': 1,
+		\ }
+<
+								*vivid#add()*
+The vivid#add() function~
+>
+	packadd Vivid.vim  " Required (this enables Vivid)
+
+	call vivid#add('tpope/vim-fugitive')                    " Simple adding from GitHub
+	call vivid#add('https://github.com/tpope/vim-fugitive') " Using full remote address to plugin
+	call vivid#add('tpope/vim-fugitive', { 'enabled': 1, }) " Enable plugin by default
+	call vivid#add('tpope/vim-fugitive', {                  " Other options to provide to Vivid
+		\ 'name': 'fugitive',
+		\ 'enabled': 1,
+		\ })
+<
+							*vivid-plugin-options*
+Plugin options~
+
+When you are adding a plugin to Vivid, options can be provided to override the
+default behaviour for that particular plugin. These options are:
+
+- 'name'
+- 'enabled'
+- 'command'
+
+The 'name' option allows the user to override the default name a plugin is
+assigned. Note: this option accepts a string.
+>
+	Plugin 'tpope/vim-fugitive', { 'name': 'fugitive' }
+<
+The 'enabled' option makes it possible to set whether the plugin is enabled or
+disabled by disabled. Note: it accepts a boolean (`0` or `1`) value, and the
+default is `0`.
+>
+	Plugin 'tpope/vim-fugitive', { 'enabled': 1 }
+<
+The 'command' option allows the user to easily define specific commands which
+will enable a plugin. This is very useful when there is a specific command
+that a plugin uses, and you would like the plugin to only be enabled when that
+command is run. Note: this option accepts a list of strings.
+>
+	Plugin 'mbbill/undotree', { 'command': ['UndotreeToggle', 'UndotreeShow'] }
+<
+In the above example running either of `:UndotreeToggle` or `:UndotreeShow`, will
+enable the `mbbill/undotree` plugin then will execute the command again, so that
+the undo tree is displayed.
+
+							*vivid-plugin-naming*
+Default plugin naming~
+
+If a name has not been provided for a plugin, Vivid will automatically create
+a name for it, here are some examples of the name it creates:
+>
+	Plugin 'tpope/vim-fugitive'   " Name would be: vim-fugitive
+	Plugin 'rhysd/committia.vim'  " Name would be: committia.vim
+	Plugin 'https://github.com/wellle/targets.vim.git'  " Name would be: targets.vim
+<
+Note: plugins cannot have the same name, if they do Vivid will only accept the
+first one. To resolve this issue, you will have to make use of the 'name'
+option.
+
+==============================================================================
+4. Installing plugins						*vivid-install*
+
+Vivid can either install plugins "on demand" or "when needed". The "on demand"
+method is when the user invokes the install command (or function).
+Alternatively, Vivid will install plugins "when needed", which essentially
+means that the plugin will auto-install when enabled.
+
+								*:PluginInstall*
+The :PluginInstall command~
+>
+	" To install the vim-fugitive and committia plugins
+	:PluginInstall vim-fugitive committia.vim
+
+	" To install all plugins
+	:PluginInstall
+<
+							*vivid#install()*
+The vivid#install() function~
+>
+	" To install the vim-fugitive and committia plugins
+	:call vivid#install('vim-fugitive', 'committia.vim')
+
+	" To install all plugins
+	:call vivid#install()
+<
+==============================================================================
+5. Updating plugins						*vivid-update*
+
+Who would have guessed it? Vivid can also update your plugins! This can be
+easily achieved by using either the command or the function provided.
+
+								*:PluginUpdate*
+The :PluginUpdate command~
+>
+	" Update specified plugins: vim-fugitive and committia
+	:PluginUpdate vim-fugitive committia.vim
+
+	" Update all plugins
+	:PluginUpdate
+<
+								*vivid#update()*
+The vivid#update() function~
+>
+	" Update specified plugins: vim-fugitive and committia
+	:call vivid#update('vim-fugitive', 'committia.vim')
+
+	" Update all plugins
+	:call vivid#update()
+<
+==============================================================================
+6. Enabling plugins						*vivid-enable*
+
+One of Vivid's main selling points is its focus on "lazy loading". This means
+that there would have to be some way for the user to define when to enable the
+plugins. That is exactly what this section covers.
+
+As you may already know, by default Vivid loads no plugins, and encourages the
+user to write their own rules for when to enable plugins. Vivid provides
+simple tools to help create these rules.
+
+These tools are:
+
+- The `:PluginEnable` command and `vivid#enable()` function,
+- The `vivid#enabled()` function,
+- The 'command' option (provided when adding plugins, check: |vivid-add|).
+
+								*:PluginEnable*
+The :PluginEnable command~
+>
+	" Enable specified plugins: vim-fugitive and committia
+	:PluginEnable vim-fugitive committia.vim
+
+	" Enable all plugins (Vundle like behaviour)
+	:PluginEnable
+<
+								*vivid#enable()*
+The vivid#enable() function~
+>
+	" Enable specified plugins: vim-fugitive and committia
+	:call vivid#enable('vim-fugitive', 'committia.vim')
+
+	" Enable all plugins
+	:call vivid#enable()
+
+<
+The vivid#enabled() function~
+
+Please refer to this section: |vivid-status|.
+
+
+The 'command' option when enabling plugins~
+
+Please refer to this section: |vivid-plugin-options|.
+
+
+Examples~
+
+This is an example of a possible use case in a vimrc:
+>
+	function! s:enable_git_plugins() abort
+		if system('git rev-parse --is-inside-work-tree') =~# '\m\C^true'
+			call vivid#enable('vim-fugitive', 'committia.vim', 'vim-gitgutter')
+		endif
+	endfunction
+	autocmd! BufReadPre * call s:enable_git_plugins()
+	" ^ This could be better optimised
+<
+And another:
+>
+	Plugin 'leafgarland/typescript-vim'
+	Plugin 'Quramy/tsuquyomi'
+
+	autocmd! FileType typescript call vivid#enable('typescript-vim', 'tsuquyomi')
+	autocmd! BufRead,BufNewFile *.ts setlocal filetype=typescript
+<
+==============================================================================
+7. Check plugin status				*vivid-status*  *vivid#enabled()*
+
+Some vim plugins set a `g:plugin_name_loaded` variable to allow the user to
+check if a particular plugin is enabled. The problem here is that not all
+plugin author's add that in, and even if they did, you would still have to
+spend some time determining what they actually named that variable.
+
+To provide a simple solution to this problem Vivid allows you to ask it
+whether it has enabled a particular plugin, through the `vivid#enabled()`
+function.
+
+The function outputs a boolean value which represents:
+
+- `0`: Disabled or not managed
+- `1`: Enabled
+
+Example use case of configuring the git commit window:
+>
+	Plugin 'rhysd/committia.vim'
+
+	function! s:configure_committia() abort
+		if vivid#enabled('committia.vim') && expand('%:t') =~# '\m\C__committia_\(diff\|status\)__'
+			setlocal nocursorline colorcolumn=
+		endif
+	endfunction
+
+	autocmd BufReadPre COMMIT_EDITMSG call vivid#enable('committia.vim')
+	autocmd FileType diff,gitcommit call <SID>configure_committia()
+<
+==============================================================================
+8. Cleaning plugins						*vivid-clean*
+
+Like all good plugin managers, Vivid is able to clean up unmanaged plugins
+from the plugin directory (where Vivid is stored).
+
+								*:PluginClean*
+The :PluginClean command~
+>
+	" Remove all unmanaged plugins
+	:PluginClean
+
+	" Remove specified managed plugins: vim-fugitive and committia
+	:PluginClean vim-fugitive committia.vim
+<
+								*vivid#clean()*
+The vivid#clean() function~
+>
+	" Remove all unmanaged plugins
+	call vivid#clean()
+
+	" Remove specified managed plugins: vim-fugitive and committia
+	call vivid#clean('vim-fugitive' 'committia.vim')
+<
+Fixing broken plugins~
+
+Occasionally a plugin may not be able to be updated (this is usually caused by
+the user). If this happens to you, there is no reason to worry, it can be
+easily fixed by removing the plugin (using `:PluginClean` or `vivid#clean()`)
+then reinstalling it.
+
+==============================================================================
+9. Messages							*vivid-messages*
+
+Vivid uses the :messages window to store logs and error messages, however only
+messages from the current session can be viewed from it.
+
 
 vim:noet:ts=8:sts=8:sw=8:tw=78:ft=help:

--- a/plugin/vivid.vim
+++ b/plugin/vivid.vim
@@ -5,18 +5,10 @@
 " Licence:      MIT Licence
 " ==============================================================================
 
-" Avoid overwriting already set commands
-try
-    command -nargs=+ -bar Plugin call vivid#add(<args>)
-    command -nargs=* -bar -complete=customlist,vivid#complete PluginInstall
-                \ call vivid#install(<f-args>)
-    command -nargs=* -bar -complete=customlist,vivid#complete PluginEnable
-                \ call vivid#enable(<f-args>)
-    command -nargs=* -bar -complete=customlist,vivid#complete PluginUpdate
-                \ call vivid#update(<f-args>)
-    command -nargs=* -bar -complete=customlist,vivid#complete PluginClean
-                \ call vivid#clean(<f-args>)
-catch /^Vim\%((\a\+)\)\=:E174/
-endtry
+command! -nargs=+ -bar Plugin call vivid#add(<args>)
+command! -nargs=* -bar -complete=customlist,vivid#complete PluginInstall call vivid#install(<f-args>)
+command! -nargs=* -bar -complete=customlist,vivid#complete PluginEnable  call vivid#enable(<f-args>)
+command! -nargs=* -bar -complete=customlist,vivid#complete PluginUpdate  call vivid#update(<f-args>)
+command! -nargs=* -bar -complete=customlist,vivid#complete PluginClean   call vivid#clean(<f-args>)
 
 " vim: set et ts=4 sts=4 sw=4 tw=80 ft=vim ff=unix fenc=utf-8 :

--- a/plugin/vivid.vim
+++ b/plugin/vivid.vim
@@ -1,7 +1,7 @@
 " ==============================================================================
 " Name:         Vivid.vim
 " Author:       Alex Vear
-" HomePage:     https://github.com/axvr/Vivid.vim
+" HomePage:     https://github.com/axvr/vivid.vim
 " Licence:      MIT Licence
 " ==============================================================================
 


### PR DESCRIPTION
A lot has changed since the previous release, the most significant of these is that Vivid has reoriented itself to a new goal of being an extremely minimal, (but yet still powerful) plugin manager for Vim.

Other changes include:

- Some of the core program logic has been simplified, and had comments added to it.
- The _VLF_ is no more, as it didn't align with the new goal.
- The initial version of the Vim help doc has _finally_ been finished.
- Other documentation changes have also been made.
- ...and more.